### PR TITLE
MC-15519: DB Compare Tool uses entity_id instead of row_id

### DIFF
--- a/app/code/Magento/MsrpSampleData/etc/module.xml
+++ b/app/code/Magento/MsrpSampleData/etc/module.xml
@@ -10,6 +10,7 @@
         <sequence>
             <module name="Magento_Msrp"/>
             <module name="Magento_SampleData"/>
+            <module name="Magento_ConfigurableSampleData"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
### Related Pull Requests
https://github.com/magento-engcom/magento2ce/pull/2927
https://github.com/magento-engcom/magento2-infrastructure/pull/97
